### PR TITLE
feat(core): support for nesting arrays of objects

### DIFF
--- a/packages/core/lib/adapters/adapter.ts
+++ b/packages/core/lib/adapters/adapter.ts
@@ -1,5 +1,5 @@
 export type ConfigSource = { [key: string]: ConfigSourceEntry };
-export type ConfigSourceEntry = string | number | boolean | ConfigSource;
+export type ConfigSourceEntry = string | number | boolean | ConfigSource | Array<ConfigSourceEntry>;
 
 export interface ConfigAdapter {
   /**

--- a/packages/core/lib/loader/decorators/nested.decorator.ts
+++ b/packages/core/lib/loader/decorators/nested.decorator.ts
@@ -1,4 +1,4 @@
-import { Type as TransformType } from 'class-transformer';
+import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { ClassConstructor } from '../../utils/class-constructor.interface';
 import { PROPERTIES_NESTING_METADATA } from '../constants';
@@ -13,7 +13,7 @@ export function Nested<T>(type: () => ClassConstructor<T>): PropertyDecorator {
     }
     mapping.set(key, type);
 
-    TransformType(type)(target, key);
+    Type(type)(target, key);
     ValidateNested()(target, key);
   };
 }

--- a/packages/core/lib/loader/loader.impl.spec.ts
+++ b/packages/core/lib/loader/loader.impl.spec.ts
@@ -1,8 +1,8 @@
 import 'reflect-metadata';
 import { TemplateMock, DbConfigMock } from '../core.mocks';
 import { ConfigLoader } from './loader.impl';
+import { From, Nested } from './decorators';
 import { Loader } from './loader';
-import { From } from './decorators';
 
 describe('ConfigLoader', () => {
   let loader: Loader;
@@ -20,7 +20,7 @@ describe('ConfigLoader', () => {
       expect(instance.db).toBeInstanceOf(DbConfigMock);
     });
 
-    it('should transform plain 1d object to 2d object', () => {
+    it('should transform plain 1d object into 2d object', () => {
       const instance = loader.load(TemplateMock, plain);
       expect(instance.port).toEqual(plain.PORT);
       expect(instance.db).toEqual({ url: plain.DB_URL, password: plain.DB_PASSWORD });
@@ -37,10 +37,28 @@ describe('ConfigLoader', () => {
       dbUrl: string;
     }
 
-    it('should transform plain 2d object to 2d object', () => {
+    it('should transform plain 2d object into 2d object', () => {
       const instance = loader.load(MultiDimensionalSourceTemplateMock, plain);
       expect(instance.port).toEqual(plain.port);
       expect(instance.dbUrl).toEqual(plain.db.url);
+    });
+  });
+
+  describe('subarray transformation', () => {
+    class SubarrayTemplateMock {
+      port: number;
+    }
+
+    class ArraySourceTemplateMock {
+      @Nested(() => SubarrayTemplateMock)
+      sub: SubarrayTemplateMock[];
+    }
+
+    const plain = { sub: [{ port: 3000 }] } satisfies ArraySourceTemplateMock;
+
+    it('should transform array source into 2d object into 2d object', () => {
+      const instance = loader.load(ArraySourceTemplateMock, plain);
+      expect(instance.sub).toEqual(plain.sub);
     });
   });
 

--- a/packages/core/lib/loader/loader.impl.ts
+++ b/packages/core/lib/loader/loader.impl.ts
@@ -23,6 +23,7 @@ export class ConfigLoader implements Loader {
     const nesting: PropertiesNesting = Reflect.getMetadata(PROPERTIES_NESTING_METADATA, template);
     if (nesting) {
       for (const [targetKey, subTemplate] of nesting) {
+        if (Array.isArray(skeleton[targetKey])) continue;
         skeleton[targetKey] = skeleton[targetKey] ?? {};
         Object.assign(
           skeleton[targetKey],

--- a/packages/core/test/core.e2e-spec.ts
+++ b/packages/core/test/core.e2e-spec.ts
@@ -5,7 +5,7 @@ import {
   ConfigManager,
   ConfigManagerFactory,
 } from '../lib';
-import { TransformationTemplate } from './templates/transformation.template';
+import { TransformationArrayTemplate, TransformationTemplate } from './templates/transformation.template';
 import { ValidationTemplate } from './templates/validation.template';
 
 describe('@unifig/core (e2e)', () => {
@@ -31,12 +31,18 @@ describe('@unifig/core (e2e)', () => {
     it('should leave missing properties blank', async () => {
       await manager.register({
         template: TransformationTemplate,
-        adapter: new PlainConfigAdapter({
-          local: { host: 'localhost' },
-          global: { dbUrl: 'localhost:5467', dbPassword: 'password' },
-        }),
+        adapter: new PlainConfigAdapter({ local: { host: 'localhost' } }),
       });
       expect(manager.getValues(TransformationTemplate).port).not.toBeDefined();
+    });
+
+    it('should transform source to array of subtemplates', async () => {
+      const ports = [{ port: 3000 }];
+      await manager.register({
+        template: TransformationArrayTemplate,
+        adapter: new PlainConfigAdapter({ ports } satisfies TransformationArrayTemplate),
+      });
+      expect(manager.getValues(TransformationArrayTemplate).ports).toEqual(ports);
     });
   });
 

--- a/packages/core/test/templates/transformation.template.ts
+++ b/packages/core/test/templates/transformation.template.ts
@@ -1,3 +1,4 @@
+import { Type } from 'class-transformer';
 import { From, Nested } from '../../lib';
 
 class DbConfig {
@@ -14,4 +15,13 @@ export class TransformationTemplate {
 
   @Nested(() => DbConfig)
   db: DbConfig;
+}
+
+class SubConfig {
+  port: number;
+}
+
+export class TransformationArrayTemplate {
+  @Type(() => SubConfig)
+  ports: SubConfig[];
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What is the new behavior?

Arrays of objects can be nested in templates.
They need to be loaded from matching plain objects via e.g. `PlainConfigAdapter`.