### PR TITLE
fix(core): patched loader logic when combining From and Nested decora…

### DIFF
--- a/packages/core/lib/loader/constants.ts
+++ b/packages/core/lib/loader/constants.ts
@@ -1,3 +1,2 @@
-export const mappedPropertyKey = (key: string) => `__unifigMappedProperty-${key}__`;
 export const PROPERTIES_MAPPING_METADATA = Symbol('unifigPropertiesMapping');
 export const PROPERTIES_NESTING_METADATA = Symbol('unifigPropertiesNesting');

--- a/packages/core/lib/loader/decorators/from.decorator.ts
+++ b/packages/core/lib/loader/decorators/from.decorator.ts
@@ -1,5 +1,5 @@
-import { Expose, Transform } from 'class-transformer';
-import { mappedPropertyKey, PROPERTIES_MAPPING_METADATA } from '../constants';
+import { Transform } from 'class-transformer';
+import { PROPERTIES_MAPPING_METADATA } from '../constants';
 import { PropertiesMapping } from '../types';
 
 interface FromOptions {
@@ -22,7 +22,5 @@ export function From(args: FromOptions | string): PropertyDecorator {
     mapping.set(key, options.key);
 
     Transform(({ value }) => value ?? options.default)(target, key);
-    // Apply custom mapping to avoid original properties overwriting.
-    Expose({ name: mappedPropertyKey(key) })(target, key);
   };
 }

--- a/packages/core/lib/loader/loader.impl.ts
+++ b/packages/core/lib/loader/loader.impl.ts
@@ -2,7 +2,7 @@ import { plainToInstance, plainToClass } from 'class-transformer';
 import { ClassConstructor } from '../utils/class-constructor.interface';
 import { overrideObject } from '../utils/override-object/override-object';
 import { ConfigSource, ConfigSourceEntry } from '../adapters/adapter';
-import { mappedPropertyKey, PROPERTIES_MAPPING_METADATA, PROPERTIES_NESTING_METADATA } from './constants';
+import { PROPERTIES_MAPPING_METADATA, PROPERTIES_NESTING_METADATA } from './constants';
 import { PropertiesMapping, PropertiesNesting, PropertySource } from './types';
 import { LoaderOptions } from './loader.options';
 import { Loader } from './loader';
@@ -17,30 +17,47 @@ export class ConfigLoader implements Loader {
   }
 
   private formatObject(template: ClassConstructor, skeleton: ConfigSource, source: ConfigSource) {
-    const properties: PropertiesMapping = Reflect.getMetadata(PROPERTIES_MAPPING_METADATA, template);
-    if (properties) {
-      for (const [targetKey, sourceKey] of properties) {
-        skeleton[mappedPropertyKey(targetKey)] = this.getSourceValue(source, sourceKey);
+    const mapping: PropertiesMapping = Reflect.getMetadata(PROPERTIES_MAPPING_METADATA, template);
+    if (mapping) {
+      for (const [targetKey, sourceKey] of mapping) {
+        skeleton[targetKey] = this.getSourceValue(source, sourceKey);
       }
     }
 
     const nesting: PropertiesNesting = Reflect.getMetadata(PROPERTIES_NESTING_METADATA, template);
     if (nesting) {
-      for (const [targetKey, subTemplate] of nesting) {
-        if (Array.isArray(skeleton[targetKey])) continue;
-        skeleton[targetKey] = skeleton[targetKey] ?? {};
-        Object.assign(
-          skeleton[targetKey],
-          this.formatObject(subTemplate(), skeleton[targetKey] as ConfigSource, source)
-        );
+      for (const [targetKey, getSubTemplate] of nesting) {
+        this.formatSubObject(targetKey, getSubTemplate, skeleton, source);
       }
     }
 
     return skeleton;
   }
 
+  private formatSubObject(
+    targetKey: string,
+    getSubTemplate: () => ClassConstructor,
+    skeleton: ConfigSource,
+    source: ConfigSource
+  ) {
+    const subTemplate = getSubTemplate();
+    const skeletonValue = skeleton[targetKey];
+
+    if (Array.isArray(skeletonValue)) {
+      for (const idx in skeletonValue) {
+        Object.assign(skeletonValue[idx], this.formatObject(subTemplate, skeletonValue[idx] as ConfigSource, source));
+      }
+    } else {
+      skeleton[targetKey] = skeletonValue ?? {};
+      Object.assign(skeleton[targetKey], this.formatObject(subTemplate, skeleton[targetKey] as ConfigSource, source));
+    }
+  }
+
   private getSourceValue(source: ConfigSource, key: PropertySource) {
-    if (source[key]) return source[key];
+    if (source[key]) {
+      return source[key];
+    }
+
     const keyParts = key.split('.');
     let value = source as ConfigSourceEntry;
     for (const keyPart of keyParts) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What is the new behavior?

`From` and `Nested` can now be incorporated to nest subtemplates from custom source objects.

## Implementation changes
Removed config source temporary keys mapping (used previously to ensure no source values will be overwritten) as it's not needed with current implementation allowing to simplify loader logic.