### PR TITLE
feat(core): added possible reasons to config not initialized message

### DIFF
--- a/packages/core/lib/manager/exceptions/__snapshots__/config-not-initialized.exception.spec.ts.snap
+++ b/packages/core/lib/manager/exceptions/__snapshots__/config-not-initialized.exception.spec.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConfigNotInitializedException should format message 1`] = `
+"Config template TemplateMock hasn't been initialized. Possible reasons:
+- It wasn't registered before accessing it
+- Its validation failed but was not handled by e.g. exiting the app"
+`;

--- a/packages/core/lib/manager/exceptions/config-not-initialized.exception.spec.ts
+++ b/packages/core/lib/manager/exceptions/config-not-initialized.exception.spec.ts
@@ -5,6 +5,6 @@ import { ConfigNotInitializedException } from './config-not-initialized.exceptio
 describe('ConfigNotInitializedException', () => {
   it('should format message', () => {
     const exception = new ConfigNotInitializedException(TemplateMock);
-    expect(exception.message).toContain(TemplateMock.name);
+    expect(exception.message).toMatchSnapshot();
   });
 });

--- a/packages/core/lib/manager/exceptions/config-not-initialized.exception.ts
+++ b/packages/core/lib/manager/exceptions/config-not-initialized.exception.ts
@@ -3,6 +3,10 @@ import { ClassConstructor } from '../../utils/class-constructor';
 
 export class ConfigNotInitializedException extends UnifigException {
   constructor(template: ClassConstructor) {
-    super(`Config template ${template.name} hasn't been initialized. Did you miss to register it?`);
+    super(
+      `Config template ${template.name} hasn't been initialized. Possible reasons:\n` +
+        "- It wasn't registered before accessing it\n" +
+        '- Its validation failed but was not handled by e.g. exiting the app'
+    );
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What is the current behavior?

Accessing not initialized config error has  suggestion only about possibly being not registered.

## What is the new behavior?

More details:
```
Config template TemplateMock hasn't been initialized. Possible reasons:
- It wasn't registered before accessing it
- Its validation failed but was not handled by e.g. exiting the app
```

