### PR TITLE
feat(core): direct subtemplates access

### DIFF
--- a/examples/01-express/src/main.ts
+++ b/examples/01-express/src/main.ts
@@ -16,8 +16,10 @@ async function bootstrap() {
 
   const app = express();
 
-  app.get('/ping', (req, res) => {
-    res.send('pong');
+  app.get('/ping', async (req, res) => {
+    const config = Config.getContainer(AppOptions);
+    await config.refresh();
+    res.send('Pong from localhost:' + config.values.port);
   });
 
   const options = Config.getValues(AppOptions);

--- a/packages/adapter-env/lib/env.adapter.spec.ts
+++ b/packages/adapter-env/lib/env.adapter.spec.ts
@@ -14,7 +14,7 @@ describe('EnvConfigAdapter', () => {
   jest
     .spyOn(dotenvExpand, 'expand')
     .mockImplementation(
-      (options: dotenvExpand.DotenvExpandOptions) => options.parsed as Record<string, string>
+      (options: dotenvExpand.DotenvExpandOptions) => options.parsed as Record<string, string>,
     );
 
   it('should load config from file', () => {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -16,13 +16,14 @@ Universal, typed and validated configuration manager.
 
 - [Installation](#installation)
 - [Setting up Templates](#templates)
-  - [Subtemplates](#templates_subtemplates)
+  - [Nested Configuration](#templates_subtemplates)
 - [Using Configuration](#loading)
   - [Quick Start](#loading_quick_start)
   - [Values Adapters](#loading_adapters)
     - [Types conversion](#loading_adapters_conversion)
     - [Functions adapters](#loading_adapters_functions)
   - [Multiple Configurations](#loading_multiple_configurations)
+  - [Accessing Nested Configuration](#loading_accessing_nested_configuration)
   - [Inline Validation Rejection](#loading_inline_rejection)
 - [Stale Data](#stale_data)
 - [Validation](#validation)
@@ -75,11 +76,11 @@ class DbSettings {
 }
 ```
 
-### Subtemplates
+### Nested Configuration
 
 <a name="templates_subtemplates"></a>
 
-They allow to keep config structure organized by grouping inseparable properties and allowing reusing of them. The subtemplate itself is declared just as regular template, including option to nest further subtemplates in it.
+Allows to keep config structure organized by grouping inseparable properties and allowing reusage of them. The subtemplate itself is declared just as regular template, including option to nest further subtemplates in it.
 
 ```ts
 export class AppSettings {
@@ -92,11 +93,11 @@ export class AppSettings {
 }
 ```
 
-## Using Configuration
+## Accessing Configuration
 
 <a name="loading"></a>
 
-Such defined templates should be loaded before any other action in the application takes place. After that configuration can be accessed from any place in the app via global `Config` reference.
+Templates should be loaded before any other action in the application takes place. After that configuration can be accessed from any place in the app via global `Config` reference.
 
 ### Quick Start
 
@@ -225,6 +226,34 @@ await Config.register(
   { template: AuthSettings, adapter: ... },
   { templates: [FilesStorageSettings, CacheSettings], adapter: ... },
 );
+```
+
+### Accessing Nested Configuration
+
+<a name="loading_accessing_nested_configuration"></a>
+
+[Nested config values](#templates_subtemplates) can be accessed directly after parent initialization.
+
+```ts
+class DbConfig {
+  @IsString()
+  url: string;
+}
+
+class AppConfig {
+  @IsInt()
+  port: number;
+
+  @Nested(() => DbConfig)
+  db: DbConfig;
+}
+
+Config.registerSync({
+  template: AppConfig,
+  adapter: () => ({ port: 3000, db: { url: 'db://localhost:5467' } }),
+});
+
+console.log('Db url: ' + Config.getValues(DbConfig).url); // => Db url: db://localhost:5467
 ```
 
 ### Inline Validation Rejection

--- a/packages/core/lib/loader/get-nested-templates/get-nested-templates.spec.ts
+++ b/packages/core/lib/loader/get-nested-templates/get-nested-templates.spec.ts
@@ -1,0 +1,19 @@
+import 'reflect-metadata';
+import { Nested } from '../decorators';
+import { getNestedTemplates } from './get-nested-templates';
+
+describe('getNestedTemplates', () => {
+  class SubarrayTemplateMock {
+    port: number;
+  }
+
+  class ArraySourceTemplateMock {
+    @Nested(() => SubarrayTemplateMock)
+    sub: SubarrayTemplateMock[];
+  }
+
+  it('should explore nested template', () => {
+    const nested = getNestedTemplates(ArraySourceTemplateMock);
+    expect(nested).toEqual([ArraySourceTemplateMock, SubarrayTemplateMock]);
+  });
+});

--- a/packages/core/lib/loader/get-nested-templates/get-nested-templates.ts
+++ b/packages/core/lib/loader/get-nested-templates/get-nested-templates.ts
@@ -1,0 +1,17 @@
+import { PropertiesNesting } from '../../shared/types';
+import { ClassConstructor } from '../../utils/class-constructor';
+import { PROPERTIES_NESTING_METADATA } from '../constants';
+
+export const getNestedTemplates = (template: ClassConstructor): ClassConstructor[] => {
+  const nesting: PropertiesNesting = Reflect.getMetadata(PROPERTIES_NESTING_METADATA, template);
+  if (!nesting) {
+    return [template];
+  }
+
+  return [
+    template,
+    ...Array.from(nesting.values()).flatMap((getSubTemplate) =>
+      getNestedTemplates(getSubTemplate()),
+    ),
+  ];
+};

--- a/packages/core/lib/loader/get-nested-templates/index.ts
+++ b/packages/core/lib/loader/get-nested-templates/index.ts
@@ -1,2 +1,1 @@
-export * from './decorators';
 export * from './get-nested-templates';

--- a/packages/core/lib/manager/source-group/source-group.impl.spec.ts
+++ b/packages/core/lib/manager/source-group/source-group.impl.spec.ts
@@ -10,7 +10,6 @@ import { ConfigAdapter } from '../../adapters';
 import { ConfigContainerMock } from '../container/container.mock';
 import { AdapterTypeMismatchException } from './exceptions';
 import { ConfigSourceGroup } from './source-group.impl';
-import { SourceGroup } from './source-group';
 
 describe('ConfigSourceGroup', () => {
   const source = { port: 3000, db: { url: 'db://localhost', password: 'password' } };
@@ -18,7 +17,7 @@ describe('ConfigSourceGroup', () => {
   describe('async adapter', () => {
     describe('class adapter', () => {
       let adapter: ConfigAdapter;
-      let sourceGroup: SourceGroup;
+      let sourceGroup: ConfigSourceGroup;
 
       beforeEach(() => {
         adapter = new ConfigAdapterMock();
@@ -26,13 +25,14 @@ describe('ConfigSourceGroup', () => {
         sourceGroup = new ConfigSourceGroup(
           new LoaderMock(),
           new ValidatorMock(),
-          () => new ConfigContainerMock()
+          () => new ConfigContainerMock(),
         );
         sourceGroup.init(adapter, [TemplateMock], {});
       });
 
       it('should load config from source', async () => {
         const instances = await sourceGroup.load();
+
         expect(instances).toHaveLength(1);
         expect(instances[0]).toEqual(source);
       });
@@ -43,13 +43,13 @@ describe('ConfigSourceGroup', () => {
     });
 
     describe('function adapter', () => {
-      let sourceGroup: SourceGroup;
+      let sourceGroup: ConfigSourceGroup;
 
       beforeEach(() => {
         sourceGroup = new ConfigSourceGroup(
           new LoaderMock(),
           new ValidatorMock(),
-          () => new ConfigContainerMock()
+          () => new ConfigContainerMock(),
         );
         sourceGroup.init(async () => source, [TemplateMock], {});
       });
@@ -67,13 +67,13 @@ describe('ConfigSourceGroup', () => {
   });
 
   describe('sync adapter', () => {
-    let sourceGroup: SourceGroup;
+    let sourceGroup: ConfigSourceGroup;
 
     beforeEach(() => {
       sourceGroup = new ConfigSourceGroup(
         new LoaderMock(),
         new ValidatorMock(),
-        () => new ConfigContainerMock()
+        () => new ConfigContainerMock(),
       );
     });
 

--- a/packages/core/lib/manager/source-group/source-group.impl.ts
+++ b/packages/core/lib/manager/source-group/source-group.impl.ts
@@ -1,5 +1,8 @@
 import { ConfigAdapter, ConfigSource, TemplateAdapter } from '../../adapters';
 import { Loader } from '../../loader/loader';
+import { getNestedTemplates } from '../../loader';
+import { PropertiesNesting } from '../../shared/types';
+import { PROPERTIES_NESTING_METADATA } from '../../loader/constants';
 import { ClassConstructor } from '../../utils/class-constructor';
 import { Validator } from '../../validator/validator';
 import { containerFactory } from '../container/container.factory';
@@ -12,17 +15,23 @@ export class ConfigSourceGroup implements SourceGroup {
   private _options: SourceGroupOptions;
   private _adapter: TemplateAdapter;
   private readonly _containers = new Map<ClassConstructor, EditableConfigContainer>();
+  private readonly _parentTemplates = new Set<ClassConstructor>();
 
   constructor(
     private readonly _loader: Loader,
     private readonly _validator: Validator,
-    private readonly _containerFactory: typeof containerFactory
+    private readonly _containerFactory: typeof containerFactory,
   ) {}
 
   init(adapter: TemplateAdapter, templates: ClassConstructor[], options: SourceGroupOptions) {
     this._options = options;
     this._adapter = adapter;
-    templates.forEach((template) => this._containers.set(template, this._containerFactory(this)));
+    templates.forEach((template) => {
+      this._parentTemplates.add(template);
+      getNestedTemplates(template).forEach((template) =>
+        this._containers.set(template, this._containerFactory(this)),
+      );
+    });
   }
 
   get templates() {
@@ -50,29 +59,47 @@ export class ConfigSourceGroup implements SourceGroup {
     const source = this.getFactoryMethod(this._adapter)();
     if (source instanceof Promise) {
       throw new AdapterTypeMismatchException(
-        this._adapter.constructor as ClassConstructor<ConfigAdapter>
+        this._adapter.constructor as ClassConstructor<ConfigAdapter>,
       );
     }
     return this.loadFromSource(source, skipValidation);
   }
 
   private getFactoryMethod(
-    adapter: TemplateAdapter
+    adapter: TemplateAdapter,
   ): (() => Promise<ConfigSource>) | (() => ConfigSource) {
     return typeof adapter === 'function' ? adapter : adapter.load.bind(adapter);
   }
 
   private loadFromSource(source: ConfigSource, skipValidation: boolean) {
-    const values = this.templates.map((template) =>
-      this._loader.load(template, source, this._options)
-    );
+    const parents = Array.from(this._parentTemplates);
+    const values = parents.map((template) => this._loader.load(template, source, this._options));
+
     if (!skipValidation) {
       const validationResult = this._validator.validate(values);
-      if (validationResult) throw validationResult;
+      if (validationResult) {
+        throw validationResult;
+      }
     }
-    this.templates.forEach((template, idx) =>
-      (this.getContainer(template) as EditableConfigContainer<any>).setValues(values[idx])
-    );
+
+    parents.forEach((template, idx) => this.setContainerValues(template, values[idx]));
+
     return values;
+  }
+
+  private setContainerValues(template: ClassConstructor, values: any) {
+    const container = this.getContainer(template) as EditableConfigContainer<any>;
+    container.setValues(values);
+
+    const nesting: PropertiesNesting = Reflect.getMetadata(PROPERTIES_NESTING_METADATA, template);
+    if (!nesting) {
+      return;
+    }
+    for (const [targetKey, getSubTemplate] of nesting) {
+      const value = values[targetKey];
+      if (value) {
+        this.setContainerValues(getSubTemplate(), value);
+      }
+    }
   }
 }

--- a/packages/core/lib/manager/source-group/source-group.impl.ts
+++ b/packages/core/lib/manager/source-group/source-group.impl.ts
@@ -97,7 +97,7 @@ export class ConfigSourceGroup implements SourceGroup {
     }
     for (const [targetKey, getSubTemplate] of nesting) {
       const value = values[targetKey];
-      if (value) {
+      if (typeof value !== 'undefined') {
         this.setContainerValues(getSubTemplate(), value);
       }
     }

--- a/packages/core/test/core.e2e-spec.ts
+++ b/packages/core/test/core.e2e-spec.ts
@@ -9,7 +9,7 @@ import {
   TransformationArrayTemplate,
   TransformationTemplate,
 } from './templates/transformation.template';
-import { ValidationTemplate } from './templates/validation.template';
+import { ValidationTemplate, DbConfig } from './templates/validation.template';
 
 describe('@unifig/core (e2e)', () => {
   let manager: ConfigManager;
@@ -79,7 +79,7 @@ describe('@unifig/core (e2e)', () => {
       const ports = [{ port: 3000 }];
       await manager.register({
         template: TransformationArrayTemplate,
-        adapter: () => ({ ports } satisfies TransformationArrayTemplate),
+        adapter: () => ({ ports }) satisfies TransformationArrayTemplate,
       });
       expect(manager.getValues(TransformationArrayTemplate).ports).toEqual(ports);
     });
@@ -99,12 +99,20 @@ describe('@unifig/core (e2e)', () => {
         manager.registerOrReject({
           template: ValidationTemplate,
           adapter: () => ({ port: 3000, db: { port: 5000 } }),
-        })
+        }),
       ).rejects.toThrow(ConfigValidationError);
     });
   });
 
   describe('registration', () => {
+    it('should register and access sub template ', () => {
+      manager.registerSync({
+        template: ValidationTemplate,
+        adapter: () => ({ port: 3000, db: { url: 'db://localhost:5467' } }),
+      });
+      expect(manager.getValues(DbConfig)).toEqual({ url: 'db://localhost:5467' });
+    });
+
     it('should fail to get config before initialization', () => {
       expect(() => manager.getValues(class {})).toThrow(ConfigNotInitializedException);
     });

--- a/packages/core/test/templates/validation.template.ts
+++ b/packages/core/test/templates/validation.template.ts
@@ -1,7 +1,7 @@
 import { IsInt, IsString } from 'class-validator';
 import { Nested } from '../../lib';
 
-class DbConfig {
+export class DbConfig {
   @IsString()
   url: string;
 }

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -106,8 +106,9 @@ export class AppModule {}
 @Injectable()
 export class AppService {
   constructor(
+    private appSettings: AppSettings, // <-- static values loaded only once on app bootstrap
     @InjectConfig() private appSettings: IConfigContainer<AppSettings>,
-    @InjectConfig(AuthSettings) private authSettings: IConfigContainer<AnotherAppSettings>
+    @InjectConfig(AuthSettings) private authSettings: IConfigContainer<AnotherAppSettings>,
   ) {}
 }
 ```

--- a/packages/nest/lib/config.module.spec.ts
+++ b/packages/nest/lib/config.module.spec.ts
@@ -5,7 +5,7 @@ describe('ConfigModule', () => {
     const injectionsWithArgument = 3;
     const injectionsWithoutArgument = 1;
     expect(
-      ConfigModule.forRoot({ default: class {}, templates: [class {}, class {}] }).providers
+      ConfigModule.forRoot({ default: class {}, templates: [class {}, class {}] }).providers,
     ).toHaveLength(injectionsWithArgument + injectionsWithoutArgument);
   });
 

--- a/packages/nest/test/mocks/cats/cats.service.ts
+++ b/packages/nest/test/mocks/cats/cats.service.ts
@@ -8,6 +8,6 @@ import { CatsConfig } from './cats.config';
 export class CatsService {
   constructor(
     @InjectConfig() readonly appConfig: ConfigContainer<AppConfig>,
-    @InjectConfig(CatsConfig) readonly catsConfig: ConfigContainer<CatsConfig>
+    @InjectConfig(CatsConfig) readonly catsConfig: ConfigContainer<CatsConfig>,
   ) {}
 }

--- a/packages/nest/test/nest.e2e-spec.ts
+++ b/packages/nest/test/nest.e2e-spec.ts
@@ -17,7 +17,7 @@ describe('@unifig/nest (e2e)', () => {
       {
         template: CatsConfig,
         adapter: new PlainConfigAdapter({ catsPort: 3000, catsHost: 'localhost' }),
-      }
+      },
     );
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,7 +2326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/supertest@npm:^2.0.16":
+"@types/supertest@npm:^2.0.12":
   version: 2.0.16
   resolution: "@types/supertest@npm:2.0.16"
   dependencies:
@@ -4946,7 +4946,7 @@ __metadata:
     "@nestjs/testing": "npm:^10.1.0"
     "@types/express": "npm:^4.17.21"
     "@types/node": "npm:^20.11.9"
-    "@types/supertest": "npm:^2.0.16"
+    "@types/supertest": "npm:^2.0.12"
     "@unifig/adapter-env": "workspace:^"
     "@unifig/core": "workspace:^"
     "@unifig/nest": "workspace:^"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What is the current behavior?

Nested configs can only be accessed via parents.

## What is the new behavior?

Nested configs can accessed directly.

```ts
class DbConfig {
  @IsString()
  url: string;
}

class AppConfig {
  @IsInt()
  port: number;

  @Nested(() => DbConfig)
  db: DbConfig;
}

Config.registerSync({
  template: AppConfig,
  adapter: () => ({ port: 3000, db: { url: 'db://localhost:5467' } }),
});

console.log('Db url: ' + Config.getValues(DbConfig).url) // => Db url: db://localhost:5467
```