### PR TITLE
fix(core): snapshots accepting nulls

### DIFF
--- a/packages/core/lib/manager/container/container.impl.ts
+++ b/packages/core/lib/manager/container/container.impl.ts
@@ -1,3 +1,4 @@
+import { DeepReadonly } from '../../utils';
 import { deepReadonly } from '../../utils/deep-readonly/deep-readonly';
 import { SourceGroup } from '../source-group/source-group';
 import { EditableConfigContainer } from './editable-container';
@@ -5,16 +6,16 @@ import { EditableConfigContainer } from './editable-container';
 export class InternalConfigContainer<TTemplate extends Record<string, any> = Record<string, any>>
   implements EditableConfigContainer<TTemplate>
 {
-  private _values: TTemplate;
+  private _values: DeepReadonly<TTemplate>;
 
   constructor(private readonly _sourceGroup: SourceGroup) {}
 
   get values() {
-    return deepReadonly(this._values);
+    return this._values;
   }
 
   setValues(values: TTemplate) {
-    this._values = values;
+    this._values = deepReadonly(values);
   }
 
   async refresh() {

--- a/packages/core/lib/utils/deep-readonly/deep-readonly.spec.ts
+++ b/packages/core/lib/utils/deep-readonly/deep-readonly.spec.ts
@@ -18,4 +18,12 @@ describe('deepReadonly', () => {
 
     expect(readonlyArray[1].val).toBe(date);
   });
+
+  it('should omit nulled values', () => {
+    const array = [{ val: 1 }, { val: null }];
+
+    const readonlyArray = deepReadonly(array);
+
+    expect(readonlyArray[1].val).toBe(null);
+  });
 });

--- a/packages/core/lib/utils/deep-readonly/deep-readonly.spec.ts
+++ b/packages/core/lib/utils/deep-readonly/deep-readonly.spec.ts
@@ -19,7 +19,7 @@ describe('deepReadonly', () => {
     expect(readonlyArray[1].val).toBe(date);
   });
 
-  it('should omit nulled values', () => {
+  it('should omit freezing nulled values', () => {
     const array = [{ val: 1 }, { val: null }];
 
     const readonlyArray = deepReadonly(array);

--- a/packages/core/lib/utils/deep-readonly/deep-readonly.ts
+++ b/packages/core/lib/utils/deep-readonly/deep-readonly.ts
@@ -18,7 +18,10 @@ export const deepReadonly = <TObject extends object>(object: TObject) => {
   for (const key in copy) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    if (typeof copy[key] === 'object' && Object.getPrototypeOf(copy[key]) === Object.prototype) {
+    const value = copy[key];
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       copy[key] = deepReadonly(copy[key]);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What is the current behavior?

Prototype of `null` can't be read. This causes `null` values in config schema to throw following error:
```ts
> Object.getPrototypeOf(null)
Uncaught TypeError: Cannot convert undefined or null to object
    at Function.getPrototypeOf (<anonymous>)
```

## What is the new behavior?
Nulls prototype check is skipped.